### PR TITLE
Fix ftdc.Iterator race and re-entrancy bugs

### DIFF
--- a/x/ftdc/go.mod
+++ b/x/ftdc/go.mod
@@ -20,4 +20,4 @@ require (
 	golang.org/x/sys v0.4.0 // indirect
 )
 
-replace github.com/tychoish/birch => ../../../birch/
+replace github.com/tychoish/birch => ../../

--- a/x/ftdc/iterator_chunk.go
+++ b/x/ftdc/iterator_chunk.go
@@ -7,46 +7,40 @@ import (
 
 	"github.com/tychoish/birch"
 	"github.com/tychoish/fun/fnx"
-	"github.com/tychoish/fun/stw"
 )
 
 // ReadChunks creates a ChunkIterator from an underlying FTDC data
 // source.
 func ReadChunks(r io.Reader) *Iterator[*Chunk] {
-	pipe := make(chan *Chunk)
-	ipc := make(chan *birch.Document)
-
 	out := &Iterator[*Chunk]{}
-
-	ch := stw.ChanBlocking(pipe)
 	msi := &metasourceImpl{}
 	out.metasource = msi
 	out.iterator = func() iter.Seq[*Chunk] {
-		wg := &fnx.WaitGroup{}
-
-		setup := fnx.Operation(func(ctx context.Context) {
-			wg.Launch(ctx, func(ctx context.Context) { out.catcher.Push(readChunks(ctx, ipc, pipe)) })
-			wg.Launch(ctx, func(ctx context.Context) { out.catcher.Push(readDiagnostic(ctx, r, ipc)) })
-			wg.Operation().Background(ctx)
-			wg.Launch(ctx, func(ctx context.Context) {
-				for {
-					select {
-					case <-ctx.Done():
-					case meta := <-ipc:
-						msi.inner.Store(meta)
-					}
-				}
-			})
-		}).Once()
-
 		return func(yield func(*Chunk) bool) {
+			pipe := make(chan *Chunk)
+			ipc := make(chan *birch.Document)
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			setup(ctx)
 
-			for elem := range ch.Receive().Iterator(ctx) {
-				if !yield(elem) {
+			wg := &fnx.WaitGroup{}
+			wg.Launch(ctx, func(ctx context.Context) { out.catcher.Push(readChunks(ctx, msi, ipc, pipe)) })
+			wg.Launch(ctx, func(ctx context.Context) { out.catcher.Push(readDiagnostic(ctx, r, ipc)) })
+
+			go func() {
+				wg.Wait(ctx)
+			}()
+
+			for {
+				select {
+				case <-ctx.Done():
 					return
+				case elem, ok := <-pipe:
+					if !ok {
+						return
+					}
+					if !yield(elem) {
+						return
+					}
 				}
 			}
 		}

--- a/x/ftdc/read.go
+++ b/x/ftdc/read.go
@@ -34,7 +34,7 @@ func readDiagnostic(ctx context.Context, f io.Reader, ch chan<- *birch.Document)
 	}
 }
 
-func readChunks(ctx context.Context, ch <-chan *birch.Document, o chan<- *Chunk) error {
+func readChunks(ctx context.Context, msi *metasourceImpl, ch <-chan *birch.Document, o chan<- *Chunk) error {
 	defer close(o)
 
 	var metadata *birch.Document
@@ -48,6 +48,9 @@ func readChunks(ctx context.Context, ch <-chan *birch.Document, o chan<- *Chunk)
 
 		if isNum(0, docType) {
 			metadata = doc
+			if msi != nil {
+				msi.inner.Store(doc)
+			}
 			continue
 		} else if !isNum(1, docType) {
 			continue


### PR DESCRIPTION
The FTDC iterator implementation had two major bugs:
1. A race condition where a metadata-collecting goroutine and the chunk-processing goroutine were both reading from the same document channel. This caused many documents to be "stolen" by the metadata collector and not processed into chunks.
2. The Iterator was not re-entrant because it used shared channels and a `Once` operation for setup. Calling `Iterator()` a second time would cause a "close of closed channel" panic or yield no data.

This PR fixes these issues by:
- Consolidating document processing and metadata collection into a single goroutine in `readChunks`.
- Moving all concurrency and channel setup inside the `iter.Seq` closure in `ReadChunks`.
- Correcting the `go.mod` file to properly resolve the local `birch` dependency.

Tests in `x/ftdc` now pass and are significantly faster.

---
*PR created automatically by Jules for task [11740137908647678115](https://jules.google.com/task/11740137908647678115) started by @tychoish*